### PR TITLE
refactor: initialize marketplaces without default auth uri

### DIFF
--- a/src/amazon-marketplace.ts
+++ b/src/amazon-marketplace.ts
@@ -172,6 +172,11 @@ export interface AmazonSellingPartner {
   readonly vendorCentralAuthUri: string
 }
 
+type AmazonSellingPartnerParameters = Omit<
+  AmazonSellingPartner,
+  'sellerCentralAuthUri' | 'vendorCentralAuthUri'
+>
+
 export interface AmazonMarketplace {
   /**
    * Amazon Marketplace ID.
@@ -260,32 +265,29 @@ export interface AmazonMarketplace {
   readonly sellingPartner?: AmazonSellingPartner
 }
 
+interface AmazonMarketplaceParameters extends Omit<AmazonMarketplace, 'sellingPartner'> {
+  sellingPartner?: AmazonSellingPartnerParameters
+}
+
 export class AmazonMarketplace implements AmazonMarketplace {
-  public constructor(amazonMarketplace: AmazonMarketplace) {
+  public constructor(amazonMarketplace: AmazonMarketplaceParameters) {
     Object.assign(this, amazonMarketplace)
 
-    /**
-     * https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/developer-guide/SellingPartnerApiDeveloperGuide.md#constructing-an-oauth-authorization-uri
-     */
-    if (
-      amazonMarketplace.sellerCentralUri &&
-      amazonMarketplace.sellingPartner?.sellerCentralAuthUri
-    ) {
-      Object.assign(amazonMarketplace.sellingPartner, {
-        sellerCentralAuthUri: `${amazonMarketplace.sellerCentralUri}/apps/authorize/consent`,
-      })
-    }
+    if (this.sellingPartner) {
+      /**
+       * https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/developer-guide/SellingPartnerApiDeveloperGuide.md#constructing-an-oauth-authorization-uri
+       */
+      if (amazonMarketplace.sellerCentralUri) {
+        Object.assign(this.sellingPartner, {
+          sellerCentralAuthUri: `${amazonMarketplace.sellerCentralUri}/apps/authorize/consent`,
+        })
+      }
 
-    /**
-     * https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/developer-guide/SellingPartnerApiDeveloperGuide.md#constructing-an-oauth-authorization-uri
-     */
-    if (
-      amazonMarketplace.vendorCentralUri &&
-      amazonMarketplace.sellingPartner?.vendorCentralAuthUri
-    ) {
-      Object.assign(amazonMarketplace.sellingPartner, {
-        vendorCentralAuthUri: `${amazonMarketplace.vendorCentralUri}/apps/authorize/consent`,
-      })
+      if (amazonMarketplace.vendorCentralUri) {
+        Object.assign(this.sellingPartner, {
+          vendorCentralAuthUri: `${amazonMarketplace.vendorCentralUri}/apps/authorize/consent`,
+        })
+      }
     }
 
     Object.freeze(this)

--- a/src/marketplaces/ae.ts
+++ b/src/marketplaces/ae.ts
@@ -6,11 +6,7 @@ import {
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
 import { marketplaceAdvertisingRegions } from '../marketplace-advertising-regions'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const AE = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.AE,
@@ -38,7 +34,5 @@ export const AE = new AmazonMarketplace({
   },
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/au.ts
+++ b/src/marketplaces/au.ts
@@ -6,11 +6,7 @@ import {
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
 import { marketplaceAdvertisingRegions } from '../marketplace-advertising-regions'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const AU = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.AU,
@@ -38,7 +34,5 @@ export const AU = new AmazonMarketplace({
   },
   sellingPartner: {
     region: sellingPartnerRegions.FE,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/br.ts
+++ b/src/marketplaces/br.ts
@@ -6,11 +6,7 @@ import {
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
 import { marketplaceAdvertisingRegions } from '../marketplace-advertising-regions'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const BR = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.BR,
@@ -38,7 +34,5 @@ export const BR = new AmazonMarketplace({
   },
   sellingPartner: {
     region: sellingPartnerRegions.NA,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/ca.ts
+++ b/src/marketplaces/ca.ts
@@ -7,11 +7,7 @@ import {
 } from '../amazon-marketplace'
 import { amazonVendorCentralUriFactory } from '../amazon-vendor-central-uri-factory'
 import { marketplaceAdvertisingRegions } from '../marketplace-advertising-regions'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 /**
  * Canada
@@ -42,7 +38,5 @@ export const CA = new AmazonMarketplace({
   },
   sellingPartner: {
     region: sellingPartnerRegions.NA,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/de.ts
+++ b/src/marketplaces/de.ts
@@ -7,11 +7,7 @@ import {
 import { amazonVendorCentralUriFactory } from '../amazon-vendor-central-uri-factory'
 import { europeanAdvertisingFactory } from '../european-advertising-factory'
 import { europeanSellerCentralUriFactory } from '../european-seller-central-uri-factory'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const DE = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.DE,
@@ -25,7 +21,5 @@ export const DE = new AmazonMarketplace({
   advertising: europeanAdvertisingFactory(AmazonMarketplaceAdvertisingCountryCode.DE),
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: sellerCentralAuthUris.EU,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/eg.ts
+++ b/src/marketplaces/eg.ts
@@ -3,10 +3,7 @@ import {
   AmazonMarketplaceAdvertisingCurrency,
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
-import {
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const EG = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.EG,
@@ -18,7 +15,5 @@ export const EG = new AmazonMarketplace({
   webServiceUri: 'https://mws-eu.amazonservices.com',
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: '',
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/es.ts
+++ b/src/marketplaces/es.ts
@@ -7,11 +7,7 @@ import {
 import { amazonVendorCentralUriFactory } from '../amazon-vendor-central-uri-factory'
 import { europeanAdvertisingFactory } from '../european-advertising-factory'
 import { europeanSellerCentralUriFactory } from '../european-seller-central-uri-factory'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const ES = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.ES,
@@ -25,7 +21,5 @@ export const ES = new AmazonMarketplace({
   advertising: europeanAdvertisingFactory(AmazonMarketplaceAdvertisingCountryCode.ES),
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: sellerCentralAuthUris.EU,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/fr.ts
+++ b/src/marketplaces/fr.ts
@@ -7,11 +7,7 @@ import {
 import { amazonVendorCentralUriFactory } from '../amazon-vendor-central-uri-factory'
 import { europeanAdvertisingFactory } from '../european-advertising-factory'
 import { europeanSellerCentralUriFactory } from '../european-seller-central-uri-factory'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const FR = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.FR,
@@ -25,7 +21,5 @@ export const FR = new AmazonMarketplace({
   advertising: europeanAdvertisingFactory(AmazonMarketplaceAdvertisingCountryCode.FR),
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: sellerCentralAuthUris.EU,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/gb.ts
+++ b/src/marketplaces/gb.ts
@@ -7,11 +7,7 @@ import {
 } from '../amazon-marketplace'
 import { europeanSellerCentralUriFactory } from '../european-seller-central-uri-factory'
 import { marketplaceAdvertisingRegions } from '../marketplace-advertising-regions'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 import { DE } from './de'
 
 if (!DE.advertising) {
@@ -44,7 +40,5 @@ export const GB = new AmazonMarketplace({
   },
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: sellerCentralAuthUris.EU,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/in.ts
+++ b/src/marketplaces/in.ts
@@ -3,11 +3,7 @@ import {
   AmazonMarketplaceAdvertisingCurrency,
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const IN = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.IN,
@@ -20,7 +16,5 @@ export const IN = new AmazonMarketplace({
   webServiceUri: 'https://mws.amazonservices.in',
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/it.ts
+++ b/src/marketplaces/it.ts
@@ -7,11 +7,7 @@ import {
 import { amazonVendorCentralUriFactory } from '../amazon-vendor-central-uri-factory'
 import { europeanAdvertisingFactory } from '../european-advertising-factory'
 import { europeanSellerCentralUriFactory } from '../european-seller-central-uri-factory'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const IT = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.IT,
@@ -25,7 +21,5 @@ export const IT = new AmazonMarketplace({
   advertising: europeanAdvertisingFactory(AmazonMarketplaceAdvertisingCountryCode.DE),
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: sellerCentralAuthUris.EU,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/jp.ts
+++ b/src/marketplaces/jp.ts
@@ -6,11 +6,7 @@ import {
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
 import { marketplaceAdvertisingRegions } from '../marketplace-advertising-regions'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const JP = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.JP,
@@ -38,7 +34,5 @@ export const JP = new AmazonMarketplace({
   },
   sellingPartner: {
     region: sellingPartnerRegions.FE,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/mx.ts
+++ b/src/marketplaces/mx.ts
@@ -6,11 +6,7 @@ import {
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
 import { marketplaceAdvertisingRegions } from '../marketplace-advertising-regions'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const MX = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.MX,
@@ -38,7 +34,5 @@ export const MX = new AmazonMarketplace({
   },
   sellingPartner: {
     region: sellingPartnerRegions.NA,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/nl.ts
+++ b/src/marketplaces/nl.ts
@@ -7,11 +7,7 @@ import {
 } from '../amazon-marketplace'
 import { amazonVendorCentralUriFactory } from '../amazon-vendor-central-uri-factory'
 import { europeanAdvertisingFactory } from '../european-advertising-factory'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 import { DE } from './de'
 
 export const NL = new AmazonMarketplace({
@@ -29,7 +25,5 @@ export const NL = new AmazonMarketplace({
   ),
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/pl.ts
+++ b/src/marketplaces/pl.ts
@@ -4,11 +4,7 @@ import {
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
 import { amazonVendorCentralUriFactory } from '../amazon-vendor-central-uri-factory'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const PL = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.PL,
@@ -21,7 +17,5 @@ export const PL = new AmazonMarketplace({
   webServiceUri: 'https://mws-eu.amazonservices.com',
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/se.ts
+++ b/src/marketplaces/se.ts
@@ -4,11 +4,7 @@ import {
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
 import { amazonVendorCentralUriFactory } from '../amazon-vendor-central-uri-factory'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const SE = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.SE,
@@ -21,7 +17,5 @@ export const SE = new AmazonMarketplace({
   webServiceUri: 'https://mws-eu.amazonservices.com',
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/sg.ts
+++ b/src/marketplaces/sg.ts
@@ -6,11 +6,7 @@ import {
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
 import { marketplaceAdvertisingRegions } from '../marketplace-advertising-regions'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const SG = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.SG,
@@ -38,7 +34,5 @@ export const SG = new AmazonMarketplace({
   },
   sellingPartner: {
     region: sellingPartnerRegions.FE,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/tr.ts
+++ b/src/marketplaces/tr.ts
@@ -3,11 +3,7 @@ import {
   AmazonMarketplaceAdvertisingCurrency,
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const TR = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.TR,
@@ -20,7 +16,5 @@ export const TR = new AmazonMarketplace({
   webServiceUri: 'https://mws-eu.amazonservices.com',
   sellingPartner: {
     region: sellingPartnerRegions.EU,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/marketplaces/us.ts
+++ b/src/marketplaces/us.ts
@@ -6,11 +6,7 @@ import {
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
 import { marketplaceAdvertisingRegions } from '../marketplace-advertising-regions'
-import {
-  sellerCentralAuthUris,
-  sellingPartnerRegions,
-  vendorCentralAuthUriTemporary,
-} from '../selling-partner-api-regions'
+import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const US = new AmazonMarketplace({
   countryCode: AmazonMarketplaceCountryCode.US,
@@ -38,7 +34,5 @@ export const US = new AmazonMarketplace({
   },
   sellingPartner: {
     region: sellingPartnerRegions.NA,
-    sellerCentralAuthUri: sellerCentralAuthUris.NA,
-    vendorCentralAuthUri: vendorCentralAuthUriTemporary, // This will be generated from Vendor Central URI
   },
 })

--- a/src/selling-partner-api-regions/index.ts
+++ b/src/selling-partner-api-regions/index.ts
@@ -7,10 +7,3 @@ export const sellingPartnerRegions = {
   FE,
   NA,
 } as const
-
-export const sellerCentralAuthUris = {
-  NA: `https://sellercentral.amazon.com`,
-  EU: `https://sellercentral-europe.amazon.com`,
-}
-
-export const vendorCentralAuthUriTemporary = 'https://vendorcentral.amazon.com'

--- a/test/__snapshots__/marketplaces.test.ts.snap
+++ b/test/__snapshots__/marketplaces.test.ts.snap
@@ -244,7 +244,6 @@ AmazonMarketplace {
       "endpoint": "https://sellingpartnerapi-eu.amazon.com",
       "name": "Europe",
     },
-    "sellerCentralAuthUri": "",
     "vendorCentralAuthUri": "https://vendorcentral.amazon.me/apps/authorize/consent",
   },
   "uri": "https://www.amazon.eg",


### PR DESCRIPTION
I think it will be better if we have a separate interface (`AmazonMarketplaceParameters`)?