### PR TITLE
feat: add Turkey to advertising

### DIFF
--- a/src/amazon-marketplace.ts
+++ b/src/amazon-marketplace.ts
@@ -72,6 +72,7 @@ export enum AmazonMarketplaceAdvertisingCountryCode {
   PL = 'PL',
   SE = 'SE',
   SG = 'SG',
+  TR = 'TR',
   UK = 'UK', // Not a real country code, but such is life. See https://github.com/ScaleLeap/amazon-marketplaces/issues/122
   US = 'US',
 }
@@ -88,6 +89,7 @@ export enum AmazonMarketplaceAdvertisingTimeZone {
   ASIA_TOKYO = 'Asia/Tokyo',
   AUSTRALIA_SYDNEY = 'Australia/Sydney',
   EUROPE_AMSTERDAM = 'Europe/Amsterdam',
+  EUROPE_ISTANBUL = 'Europe/Istanbul',
   EUROPE_LONDON = 'Europe/London',
   EUROPE_PARIS = 'Europe/Paris',
   EUROPE_STOCKHOLM = 'Europe/Stockholm',

--- a/src/marketplaces/in.ts
+++ b/src/marketplaces/in.ts
@@ -22,12 +22,12 @@ export const IN = new AmazonMarketplace({
     region: marketplaceAdvertisingRegions.EU,
     bids: {
       sponsoredBrands: {
-        min: 1,
-        max: 2000,
+        min: 100,
+        max: 200000,
       },
       sponsoredProducts: {
-        min: 1,
-        max: 5000,
+        min: 100,
+        max: 500000,
       },
     },
     timeZone: AmazonMarketplaceAdvertisingTimeZone.ASIA_INDIA,

--- a/src/marketplaces/pl.ts
+++ b/src/marketplaces/pl.ts
@@ -23,7 +23,7 @@ export const PL = new AmazonMarketplace({
     region: marketplaceAdvertisingRegions.EU,
     bids: {
       sponsoredBrands: {
-        min: 2,
+        min: 20,
         max: 20000,
       },
       sponsoredProducts: {

--- a/src/marketplaces/se.ts
+++ b/src/marketplaces/se.ts
@@ -23,8 +23,8 @@ export const SE = new AmazonMarketplace({
     region: marketplaceAdvertisingRegions.EU,
     bids: {
       sponsoredBrands: {
-        min: 900,
-        max: 940000000,
+        min: 90,
+        max: 50000,
       },
       sponsoredProducts: {
         min: 18,

--- a/src/marketplaces/tr.ts
+++ b/src/marketplaces/tr.ts
@@ -1,8 +1,11 @@
 import {
   AmazonMarketplace,
+  AmazonMarketplaceAdvertisingCountryCode,
   AmazonMarketplaceAdvertisingCurrency,
+  AmazonMarketplaceAdvertisingTimeZone,
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
+import { marketplaceAdvertisingRegions } from '../marketplace-advertising-regions'
 import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const TR = new AmazonMarketplace({
@@ -14,6 +17,21 @@ export const TR = new AmazonMarketplace({
   sellerCentralUri: 'https://sellercentral.amazon.com.tr',
   vendorCentralUri: 'https://vendorcentral.amazon.com.tr',
   webServiceUri: 'https://mws-eu.amazonservices.com',
+  advertising: {
+    countryCode: AmazonMarketplaceAdvertisingCountryCode.TR,
+    region: marketplaceAdvertisingRegions.EU,
+    bids: {
+      sponsoredBrands: {
+        min: 20,
+        max: 20000,
+      },
+      sponsoredProducts: {
+        min: 5,
+        max: 250000,
+      },
+    },
+    timeZone: AmazonMarketplaceAdvertisingTimeZone.EUROPE_ISTANBUL,
+  },
   sellingPartner: {
     region: sellingPartnerRegions.EU,
   },

--- a/test/__snapshots__/marketplaces.test.ts.snap
+++ b/test/__snapshots__/marketplaces.test.ts.snap
@@ -389,12 +389,12 @@ AmazonMarketplace {
   "advertising": Object {
     "bids": Object {
       "sponsoredBrands": Object {
-        "max": 2000,
-        "min": 1,
+        "max": 200000,
+        "min": 100,
       },
       "sponsoredProducts": Object {
-        "max": 5000,
-        "min": 1,
+        "max": 500000,
+        "min": 100,
       },
     },
     "countryCode": "IN",
@@ -610,7 +610,7 @@ AmazonMarketplace {
     "bids": Object {
       "sponsoredBrands": Object {
         "max": 20000,
-        "min": 2,
+        "min": 20,
       },
       "sponsoredProducts": Object {
         "max": 200000000,
@@ -665,8 +665,8 @@ AmazonMarketplace {
   "advertising": Object {
     "bids": Object {
       "sponsoredBrands": Object {
-        "max": 940000000,
-        "min": 900,
+        "max": 50000,
+        "min": 90,
       },
       "sponsoredProducts": Object {
         "max": 930000,
@@ -750,6 +750,27 @@ AmazonMarketplace {
 
 exports[`marketplace TR should match snapshot 1`] = `
 AmazonMarketplace {
+  "advertising": Object {
+    "bids": Object {
+      "sponsoredBrands": Object {
+        "max": 20000,
+        "min": 20,
+      },
+      "sponsoredProducts": Object {
+        "max": 250000,
+        "min": 5,
+      },
+    },
+    "countryCode": "TR",
+    "region": AmazonMarketplaceAdvertisingRegion {
+      "accessTokenUri": "https://api.amazon.co.uk/auth/o2/token",
+      "authorizationUri": "https://eu.account.amazon.com/ap/oa",
+      "code": "EU",
+      "endpoint": "https://advertising-api-eu.amazon.com",
+      "name": "Europe",
+    },
+    "timeZone": "Europe/Istanbul",
+  },
   "countryCode": "TR",
   "currency": "TRY",
   "id": "A33AVAJ2PDY3EV",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../src/utils'
 
 describe('utils', () => {
-  const { CA, TR } = amazonMarketplaces
+  const { CA, EG } = amazonMarketplaces
 
   describe(`${findAmazonMarketplace.name}`, () => {
     it('should find by id', () => {
@@ -69,7 +69,7 @@ describe('utils', () => {
     it('should throw when advertising is not available', () => {
       expect.assertions(1)
 
-      expect(() => assertMarketplaceHasAdvertising(TR)).toThrow(/does not have advertising/)
+      expect(() => assertMarketplaceHasAdvertising(EG)).toThrow(/does not have advertising/)
     })
   })
 })


### PR DESCRIPTION
BREAKING CHANGE:
- add Turkey to advertising
- update bid constraints by marketplace: IN, PL, SE

Ref:
- [Bid constraints by marketplace](https://advertising.amazon.com/API/docs/en-us/concepts/limits#bid-constraints-by-marketplace)
- [Profile API](https://advertising.amazon.com/API/docs/en-us/reference/2/profiles)

Closes #491