### PR TITLE
feat: add Egypt to advertising

### DIFF
--- a/src/amazon-marketplace.ts
+++ b/src/amazon-marketplace.ts
@@ -62,6 +62,7 @@ export enum AmazonMarketplaceAdvertisingCountryCode {
   BR = 'BR',
   CA = 'CA',
   DE = 'DE',
+  EG = 'EG',
   ES = 'ES',
   FR = 'FR',
   IN = 'IN',
@@ -81,6 +82,7 @@ export enum AmazonMarketplaceAdvertisingCountryCode {
  * Time Zone enum.
  */
 export enum AmazonMarketplaceAdvertisingTimeZone {
+  AFRICA_CAIRO = 'Africa/Cairo',
   AMERICA_LOS_ANGELES = 'America/Los_Angeles',
   AMERICA_SAO_PAULO = 'America/Sao_Paulo',
   ASIA_DUBAI = 'Asia/Dubai',

--- a/src/marketplaces/eg.ts
+++ b/src/marketplaces/eg.ts
@@ -1,8 +1,11 @@
 import {
   AmazonMarketplace,
+  AmazonMarketplaceAdvertisingCountryCode,
   AmazonMarketplaceAdvertisingCurrency,
+  AmazonMarketplaceAdvertisingTimeZone,
   AmazonMarketplaceCountryCode,
 } from '../amazon-marketplace'
+import { marketplaceAdvertisingRegions } from '../marketplace-advertising-regions'
 import { sellingPartnerRegions } from '../selling-partner-api-regions'
 
 export const EG = new AmazonMarketplace({
@@ -13,6 +16,21 @@ export const EG = new AmazonMarketplace({
   uri: 'https://www.amazon.eg',
   vendorCentralUri: 'https://vendorcentral.amazon.me',
   webServiceUri: 'https://mws-eu.amazonservices.com',
+  advertising: {
+    countryCode: AmazonMarketplaceAdvertisingCountryCode.EG,
+    region: marketplaceAdvertisingRegions.EU,
+    bids: {
+      sponsoredBrands: {
+        min: 70,
+        max: 40000,
+      },
+      sponsoredProducts: {
+        min: 15,
+        max: 550,
+      },
+    },
+    timeZone: AmazonMarketplaceAdvertisingTimeZone.AFRICA_CAIRO,
+  },
   sellingPartner: {
     region: sellingPartnerRegions.EU,
   },

--- a/src/marketplaces/mx.ts
+++ b/src/marketplaces/mx.ts
@@ -23,7 +23,7 @@ export const MX = new AmazonMarketplace({
     bids: {
       sponsoredBrands: {
         min: 10,
-        max: 50000,
+        max: 2000000,
       },
       sponsoredProducts: {
         min: 10,

--- a/src/marketplaces/pl.ts
+++ b/src/marketplaces/pl.ts
@@ -27,8 +27,8 @@ export const PL = new AmazonMarketplace({
         max: 20000,
       },
       sponsoredProducts: {
-        min: 200,
-        max: 200000000,
+        min: 4,
+        max: 200000,
       },
     },
     timeZone: AmazonMarketplaceAdvertisingTimeZone.EUROPE_WARSAW,

--- a/test/__snapshots__/marketplaces.test.ts.snap
+++ b/test/__snapshots__/marketplaces.test.ts.snap
@@ -233,6 +233,27 @@ AmazonMarketplace {
 
 exports[`marketplace EG should match snapshot 1`] = `
 AmazonMarketplace {
+  "advertising": Object {
+    "bids": Object {
+      "sponsoredBrands": Object {
+        "max": 40000,
+        "min": 70,
+      },
+      "sponsoredProducts": Object {
+        "max": 550,
+        "min": 15,
+      },
+    },
+    "countryCode": "EG",
+    "region": AmazonMarketplaceAdvertisingRegion {
+      "accessTokenUri": "https://api.amazon.co.uk/auth/o2/token",
+      "authorizationUri": "https://eu.account.amazon.com/ap/oa",
+      "code": "EU",
+      "endpoint": "https://advertising-api-eu.amazon.com",
+      "name": "Europe",
+    },
+    "timeZone": "Africa/Cairo",
+  },
   "countryCode": "EG",
   "currency": "EGP",
   "id": "ARBP9OOSHTCHU",
@@ -521,7 +542,7 @@ AmazonMarketplace {
   "advertising": Object {
     "bids": Object {
       "sponsoredBrands": Object {
-        "max": 50000,
+        "max": 2000000,
         "min": 10,
       },
       "sponsoredProducts": Object {
@@ -613,8 +634,8 @@ AmazonMarketplace {
         "min": 20,
       },
       "sponsoredProducts": Object {
-        "max": 200000000,
-        "min": 200,
+        "max": 200000,
+        "min": 4,
       },
     },
     "countryCode": "PL",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../src/utils'
 
 describe('utils', () => {
-  const { CA, EG } = amazonMarketplaces
+  const { CA, CN } = amazonMarketplaces
 
   describe(`${findAmazonMarketplace.name}`, () => {
     it('should find by id', () => {
@@ -69,7 +69,7 @@ describe('utils', () => {
     it('should throw when advertising is not available', () => {
       expect.assertions(1)
 
-      expect(() => assertMarketplaceHasAdvertising(EG)).toThrow(/does not have advertising/)
+      expect(() => assertMarketplaceHasAdvertising(CN)).toThrow(/does not have advertising/)
     })
   })
 })


### PR DESCRIPTION
- add Egypt to advertising.
- update `mx` Sponsored Brands bid.
- update `pl` Sponsored Products bid.

Closes #517;