### PR TITLE
Revert "ci: use Node.js v16 for release actions"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install
         run: npm ci


### PR DESCRIPTION
Reverts ScaleLeap/amazon-marketplaces#623