### PR TITLE
fix: entry points in the build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ const eslint = {
   parserOptions: {
     ecmaVersion: 9,
     sourceType: 'module',
-    project: './tsconfig.json',
+    project: './tsconfig.eslint.json',
   },
   ignorePatterns: ['.eslintrc.js', 'dist'],
   env: {

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,1 +1,0 @@
-module.exports = require('@scaleleap/utils/lint-staged')

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*",
+    "test/**/*.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "target": "ES2019"
   },
   "include": [
-    "src/**/*",
-    "test/**/*.ts"
+    "src/**/*"
   ]
 }


### PR DESCRIPTION
There was a bug when deleting `@scaleleap/utils` package from our repository.
Including `"test/**/*.ts"` into `tsconfig.json` leaded to loosing entry points in the build.

https://github.com/ScaleLeap/amazon-marketplaces/pull/619/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0R12


Closes #634 ;